### PR TITLE
Ticked version, regenerated if needed. (Double-check reqs!)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
 test:
   imports:
     - zodburi
-    - zodburi.tests
 
 about:
   home: https://github.com/Pylons/zodburi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "zodburi" %}
-{% set version = "2.0" %}
+{% set version = "2.2.2" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "c04b9beca032bb7b968a3464417596ba4607a927c5e65929860962ddba1cccc0" %}
+{% set hash = "535c156230983ff31d878aa1bc451a4891757fe05d3e499e7ed5f363e7cccc42" %}
 {% set build = 0 %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,15 +26,19 @@ requirements:
   run:
     - python
     - setuptools
+    - zodb
+    - zconfig
+    - zeo
 
 test:
   imports:
     - zodburi
+    - zodburi.tests
 
 about:
   home: https://github.com/Pylons/zodburi
+  license_file: LICENSE.txt
   license: ZPL 2.1
-  # license_file: No MANIFEST.in
   license_family: Other
   summary: 'Construct ZODB storage instances from URIs.'
   doc_url: https://zodburi.readthedocs.io/en/latest/


### PR DESCRIPTION
(Made using `tick_my_feedstocks.py`)
- [x] **I vetted this feedstock**